### PR TITLE
Question about usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function getChunk(readerClient, slice, opConfig, logger) {
 
     return readerClient(slice.offset, slice.length)
         .then((data) => {
+            console.log('DATA:', data);
             const finalChar = data[data.length - 1];
             // Skip the margin if the raw data ends with a newline since it will end with a complete
             // record


### PR DESCRIPTION
I think the splitting on delimiter should happen in the slicer, but there's probably something simple I'm just not getting.  Using the [hdfs reader as example](https://github.com/terascope/hdfs-assets/blob/9b609f3a36bbe8eaf41925765b6068a2d53dd463/assets/hdfs_reader/index.js#L26), it's not clear how records are handled when the chunk does not fall on delimiter boundaries.  Is this a valid use case?  If so, can you see what am I doing wrong?